### PR TITLE
chore: configure the package manager in the root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
     "**/*.{js,jsx,ts,tsx,mdx}": [
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "pnpm@8.6.12"
 }


### PR DESCRIPTION
Configures the root `package.json` to use pnpm as its package manager. 