### PR TITLE
chore: update codeowners for marketing content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 /LICENSE                            @tjrgg
 /.github                            @nsylke @tjrgg
 /.github/SECURITY.md                @nsylke
-/apps/marketing/src/content/legal   @tjrgg
 /apps/marketing/src/content         @nsylke @tjrgg
+/apps/marketing/src/content/legal   @tjrgg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
-*                       @nsylke
-/LICENSE                @tjrgg
-/.github                @nsylke @tjrgg
-/.github/SECURITY.md    @nsylke
+*                                   @nsylke
+/LICENSE                            @tjrgg
+/.github                            @nsylke @tjrgg
+/.github/SECURITY.md                @nsylke
+/apps/marketing/src/content/legal   @tjrgg
+/apps/marketing/src/content         @nsylke @tjrgg


### PR DESCRIPTION
Update the CODEOWNERS to give @tjrgg the ownership over `/apps/marketing/src/content/legal`