### PR TITLE
refactor: move header and footer component to root layout

### DIFF
--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next";
 import { Inter } from "next/font/google";
 import React from "react";
 
+import Footer from "../components/Footer";
+import Header from "../components/Header";
 import "../styles/globals.css";
 
 const inter = Inter({
@@ -29,7 +31,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={inter.variable}>
-      <body className="bg-slate-900">{children}</body>
+      <body className="bg-slate-900">
+        <Header />
+        {children}
+        <Footer />
+      </body>
     </html>
   );
 }

--- a/apps/marketing/src/app/legal/[content]/page.tsx
+++ b/apps/marketing/src/app/legal/[content]/page.tsx
@@ -2,9 +2,6 @@ import { allLegalDocuments } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import { notFound } from "next/navigation";
 
-import Footer from "../../../components/Footer";
-import Header from "../../../components/Header";
-
 export const generateStaticParams = async () =>
   allLegalDocuments.map((doc) => ({ content: doc._raw.flattenedPath }));
 
@@ -18,12 +15,8 @@ export default function Page({ params }: { params: { content: string } }) {
   const MDXContent = useMDXComponent(doc.body.code);
 
   return (
-    <>
-      <Header />
-      <article className="prose prose-invert mx-auto max-w-2xl px-4 py-24 sm:px-6 sm:py-32 lg:max-w-7xl lg:px-8">
-        <MDXContent />
-      </article>
-      <Footer />
-    </>
+    <article className="prose prose-invert mx-auto max-w-2xl px-4 py-24 sm:px-6 sm:py-32 lg:max-w-7xl lg:px-8">
+      <MDXContent />
+    </article>
   );
 }

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -1,19 +1,15 @@
 import Faq from "../components/Faq";
 import Features from "../components/Features";
-import Footer from "../components/Footer";
-import Header from "../components/Header";
 import Hero from "../components/Hero";
 import Waitlist from "../components/Waitlist";
 
 export default function Page() {
   return (
     <>
-      <Header />
       <Hero />
       <Features />
       <Faq />
       <Waitlist />
-      <Footer />
     </>
   );
 }


### PR DESCRIPTION
Move the header and footer component to the root layout, thus we don't import those components on every page. 