### PR TITLE
refactor: use @scure/base to handle utf8 encoding and decoding

### DIFF
--- a/packages/tracker-crypto/src/box.ts
+++ b/packages/tracker-crypto/src/box.ts
@@ -1,7 +1,7 @@
-import { base64url } from "@scure/base";
+import { base64url, utf8 } from "@scure/base";
 import { box, randomBytes } from "tweetnacl";
 
-import { NaclBoxKey, parse, utf8Decode, utf8Encode } from "./common";
+import { NaclBoxKey, parse } from "./common";
 
 /**
  * Formatted key with the public base64 encoded from the key pair.
@@ -65,7 +65,7 @@ export function importBoxKeyPair(secretKey: string): NaclBoxKey {
 export function boxEncrypt(input: string, publicKey: Uint8Array): string {
   const nonce = randomBytes(box.nonceLength);
   const keyPair = box.keyPair();
-  const ciphertext = box(utf8Encode(input), nonce, publicKey, keyPair.secretKey);
+  const ciphertext = box(utf8.decode(input), nonce, publicKey, keyPair.secretKey);
 
   return `trpkit.naclbox.${base64url.encode(publicKey)}.${base64url.encode(
     nonce
@@ -96,5 +96,5 @@ export function boxDecrypt(input: string, secretKey: Uint8Array): string {
     throw new Error("invalid input");
   }
 
-  return utf8Decode(message);
+  return utf8.encode(message);
 }

--- a/packages/tracker-crypto/src/common.ts
+++ b/packages/tracker-crypto/src/common.ts
@@ -1,9 +1,6 @@
 import { base64url } from "@scure/base";
 import { BoxKeyPair, SignKeyPair } from "tweetnacl";
 
-const encoder = new TextEncoder();
-const decoder = new TextDecoder();
-
 /**
  * @param public - Formatted key with the public base64 encoded from the key pair.
  * @param secret - Formatted key with the secret base64 encoded from the key pair.
@@ -38,18 +35,4 @@ export function parse(input: string, regex: RegExp): Uint8Array {
   }
 
   return base64url.decode(input);
-}
-
-/**
- * @param input - The input string to encode.
- */
-export function utf8Encode(input: string): Uint8Array {
-  return encoder.encode(input);
-}
-
-/**
- * @param input - The input buffer to decode.
- */
-export function utf8Decode(input: Uint8Array): string {
-  return decoder.decode(input);
 }

--- a/packages/tracker-crypto/src/signature.ts
+++ b/packages/tracker-crypto/src/signature.ts
@@ -1,7 +1,7 @@
-import { base64url } from "@scure/base";
+import { base64url, utf8 } from "@scure/base";
 import { sign } from "tweetnacl";
 
-import { NaclSignatureKey, parse, utf8Decode, utf8Encode } from "./common";
+import { NaclSignatureKey, parse } from "./common";
 
 /**
  * Formatted key with the public base64 encoded from the key pair.
@@ -62,7 +62,7 @@ export function importSignatureKeyPair(secretKey: string): NaclSignatureKey {
  * @param secretKey - The secret key to use.
  */
 export function makeSignature(input: string, secretKey: Uint8Array): string {
-  const signature = sign(utf8Encode(input), secretKey);
+  const signature = sign(utf8.decode(input), secretKey);
   return `trpkit.naclsignature.${base64url.encode(signature)}`;
 }
 
@@ -85,5 +85,5 @@ export function verifySignature(input: string, publicKey: Uint8Array): string {
     throw new Error("invalid input");
   }
 
-  return utf8Decode(signature);
+  return utf8.encode(signature);
 }


### PR DESCRIPTION
Use the `utf8.encode` and `utf8.decode` functions from [@scure/base](https://github.com/paulmillr/scure-base) instead of writing our own encoder/decoder. 