### PR TITLE
build: update marketing port in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: apps/marketing/Dockerfile
     ports:
-      - "3000:3000"
+      - "3002:3000"
     profiles:
       - fullstack
       - production


### PR DESCRIPTION
Change the port of the marketing container to 3002 in docker-compose configuration.