### PR TITLE
chore: ignore env files example .env.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 .idea
 *.iml
 .contentlayer
+.env*
+!.env.example


### PR DESCRIPTION
Ignore all environment files except for `.env.example` 