### PR TITLE
chore: grant @tjrgg ownership over enterprise license files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 *                                   @nsylke
 /LICENSE                            @tjrgg
+**/ee/LICENSE                       @tjrgg
 /.github                            @nsylke @tjrgg
 /.github/SECURITY.md                @nsylke
 /apps/marketing/src/content         @nsylke @tjrgg


### PR DESCRIPTION
Grant @tjrgg ownership over any `ee/LICENSE` files. 