### PR TITLE
refactor: move tailwindcss config to separate package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,10 @@
 "app: url-shortener":
   - apps/trpk.it/**
 
+"package: config":
+  - packages/config/**
+  - packages/ts-config/**
+
 "package: kms":
   - packages/kms/**
 

--- a/apps/marketing/next.config.js
+++ b/apps/marketing/next.config.js
@@ -9,6 +9,7 @@ plugins.push(withContentlayer);
 const config = {
   reactStrictMode: true,
   output: "standalone",
+  transpilePackages: ["@trpkit/config"],
 };
 
 module.exports = () => plugins.reduce((acc, next) => next(acc), config);

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.4",
     "@tailwindcss/typography": "^0.5.9",
+    "@trpkit/config": "workspace:*",
     "@types/node": "^20.5.0",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",

--- a/apps/marketing/tailwind.config.js
+++ b/apps/marketing/tailwind.config.js
@@ -1,14 +1,8 @@
+const base = require("@trpkit/config/tailwind-default");
+
 /**
  * @type {import('tailwindcss').Config}
  */
 module.exports = {
-  content: ["./src/**/*.{js,jsx,ts,tsx,mdx}"],
-  theme: {
-    extend: {
-      fontFamily: {
-        sans: ["var(--font-inter)"],
-      },
-    },
-  },
-  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/typography")],
+  ...base,
 };

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@trpkit/config",
+  "version": "0.0.1",
+  "private": true,
+  "files": [
+    "tailwind-default.js"
+  ],
+  "devDependencies": {
+    "@tailwindcss/forms": "^0.5.4",
+    "@tailwindcss/typography": "^0.5.9",
+    "tailwindcss": "^3.3.3"
+  }
+}

--- a/packages/config/tailwind-default.js
+++ b/packages/config/tailwind-default.js
@@ -1,0 +1,15 @@
+/**
+ * @type {import('tailwindcss').Config}
+ */
+module.exports = {
+  content: ["./src/**/*.{js,jsx,ts,tsx,mdx}"],
+  darkMode: "class",
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-inter)"],
+      },
+    },
+  },
+  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/typography")],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.9
         version: 0.5.9(tailwindcss@3.3.3)
+      '@trpkit/config':
+        specifier: workspace:*
+        version: link:../../packages/config
       '@types/node':
         specifier: ^20.5.0
         version: 20.5.0
@@ -130,6 +133,18 @@ importers:
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
+
+  packages/config:
+    devDependencies:
+      '@tailwindcss/forms':
+        specifier: ^0.5.4
+        version: 0.5.4(tailwindcss@3.3.3)
+      '@tailwindcss/typography':
+        specifier: ^0.5.9
+        version: 0.5.9(tailwindcss@3.3.3)
+      tailwindcss:
+        specifier: ^3.3.3
+        version: 3.3.3
 
   packages/storage:
     dependencies:


### PR DESCRIPTION
Move tailwindcss config to separate package. This package will be used for other configuration files as well. 