### PR TITLE
feat: implement next-themes to toggle between system, dark and light

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -13,6 +13,7 @@
     "contentlayer": "^0.3.4",
     "next": "^13.4.16",
     "next-contentlayer": "^0.3.4",
+    "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sharp": "^0.32.5"

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -5,6 +5,8 @@ import { Metadata } from "next";
 import { Inter } from "next/font/google";
 import React from "react";
 
+import Providers from "./providers";
+
 const inter = Inter({
   subsets: ["latin"],
   display: "swap",
@@ -29,11 +31,13 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en" className={inter.variable} suppressHydrationWarning>
       <body className="bg-slate-900">
-        <Header />
-        {children}
-        <Footer />
+        <Providers>
+          <Header />
+          {children}
+          <Footer />
+        </Providers>
       </body>
     </html>
   );

--- a/apps/marketing/src/app/providers.tsx
+++ b/apps/marketing/src/app/providers.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { ThemeProvider } from "next-themes";
+import React from "react";
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider attribute="class">{children}</ThemeProvider>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       next-contentlayer:
         specifier: ^0.3.4
         version: 0.3.4(contentlayer@0.3.4)(esbuild@0.19.2)(next@13.4.16)(react-dom@18.2.0)(react@18.2.0)
+      next-themes:
+        specifier: ^0.2.1
+        version: 0.2.1(next@13.4.16)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -4737,6 +4740,18 @@ packages:
       - esbuild
       - markdown-wasm
       - supports-color
+    dev: false
+
+  /next-themes@0.2.1(next@13.4.16)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}
+    peerDependencies:
+      next: '*'
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      next: 13.4.16(@opentelemetry/api@1.4.1)(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /next@13.4.16(@opentelemetry/api@1.4.1)(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
Implement [next-themes](https://github.com/pacocoursey/next-themes) provider to toggle between system, dark and light mode. The actual component will be implemented in another PR. 