### PR TITLE
ci: fix labeler config for tsconfig package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,7 +20,7 @@
 
 "package: config":
   - packages/config/**
-  - packages/ts-config/**
+  - packages/tsconfig/**
 
 "package: kms":
   - packages/kms/**


### PR DESCRIPTION
Correct the path to the tsconfig package in labeler config 