### PR TITLE
chore: bump version

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/marketing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/root",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/common",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/config",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "files": [
     "tailwind-default.js"

--- a/packages/kms/package.json
+++ b/packages/kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/kms",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/storage",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/tracker-crypto/package.json
+++ b/packages/tracker-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/tracker-crypto",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/tracker-script/package.json
+++ b/packages/tracker-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpkit/tracker-script",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "build": "spack"


### PR DESCRIPTION
As of tomorrow (09/17) our 0.2.0 milestone will come to an end. This PR prepares to update the version.