### PR TITLE
fix: remove disallow property of _next from robots

### DIFF
--- a/apps/marketing/src/app/robots.ts
+++ b/apps/marketing/src/app/robots.ts
@@ -2,11 +2,11 @@ import { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/*",
-      disallow: ["/_next/*"],
-    },
+    rules: [
+      {
+        userAgent: "*",
+      },
+    ],
     sitemap: `${process.env.NEXT_PUBLIC_BASE_URL || "https://trpkit.com"}/sitemap.xml`,
   };
 }


### PR DESCRIPTION
The `_next` is breaking the GSC mobile usability. This resolves it. 