### PR TITLE
chore: add crates to workspaces

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
   - "apps/*"
-  - "incubators/*"
+  - "crates/*"
   - "packages/*"


### PR DESCRIPTION
- Remove `incubators` from workspaces
- Add `crates` to workspaces

We'll be separating our Rust crates (packages) from our TypeScript packages. 