### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,3 @@
 /LICENSE                            @tjrgg
 /.github                            @nsylke @tjrgg
 /.github/SECURITY.md                @nsylke
-/apps/marketing/src/content         @nsylke @tjrgg
-/apps/marketing/src/content/legal   @tjrgg


### PR DESCRIPTION
In #89 we moved our blog and legal documents over to [trpkit/materials](https://github.com/trpkit/materials) so we could license it under a different license. These paths are ignored, thus we don't need specify code ownership here anymore. 