### PR TITLE
refactor: move client-side crypto functions into tracker script

### DIFF
--- a/packages/tracker/package.json
+++ b/packages/tracker/package.json
@@ -3,10 +3,15 @@
   "version": "0.6.0",
   "private": true,
   "scripts": {
-    "build": "ts-node ./scripts/build.ts"
+    "build": "ts-node ./scripts/build.ts",
+    "size": "ts-node ./scripts/size.ts"
   },
   "dependencies": {
-    "@trpkit/crypto": "workspace:*"
+    "@noble/ciphers": "^0.5.3",
+    "@noble/curves": "^1.6.0",
+    "@noble/hashes": "^1.5.0",
+    "@noble/post-quantum": "^0.2.0",
+    "@scure/base": "^1.1.8"
   },
   "devDependencies": {
     "@types/node": "^20.16.5",

--- a/packages/tracker/scripts/build.ts
+++ b/packages/tracker/scripts/build.ts
@@ -6,8 +6,11 @@ const options: BuildOptions = {
   outfile: resolve(__dirname, "../dist/analytics.js"),
   bundle: true,
   minify: true,
-  sourcemap: true,
+  sourcemap: false,
   format: "iife",
+  platform: "browser",
+  legalComments: "linked",
+  charset: "utf8",
   target: ["chrome58", "firefox57", "safari11", "edge18"],
 };
 

--- a/packages/tracker/scripts/size.ts
+++ b/packages/tracker/scripts/size.ts
@@ -1,0 +1,17 @@
+import { readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { gzipSync } from "node:zlib";
+
+const filePath = resolve(__dirname, "../dist/analytics.js");
+
+// File size
+const fileStats = statSync(filePath);
+const nonGzippedSize = fileStats.size;
+
+// Gzip file size
+const fileContent = readFileSync(filePath);
+const gzippedContent = gzipSync(fileContent);
+const gzippedSize = gzippedContent.length;
+
+console.log(`Non-gzipped size: ${(nonGzippedSize / 1024).toFixed(2)} KB`);
+console.log(`Gzipped size: ${(gzippedSize / 1024).toFixed(2)} KB`);

--- a/packages/tracker/src/config.ts
+++ b/packages/tracker/src/config.ts
@@ -1,9 +1,10 @@
-import { parse, publicKeyRegex } from "@trpkit/crypto";
+import { parse } from "./crypto";
 
 export const baseUrl = "https://ingress.trpkit.com/v1/event/";
 
 export type Config = {
   publicKey: Uint8Array;
+  pqPublicKey: Uint8Array;
   siteId: string;
 };
 
@@ -13,12 +14,14 @@ export function readConfig(): Config | null {
     if (!config) return null;
 
     const publicKey = config.dataset.publicKey;
+    const pqPublicKey = config.dataset.pqPublicKey;
     const siteId = config.dataset.siteId;
 
-    if (!publicKey || !siteId) return null;
+    if (!publicKey || !pqPublicKey || !siteId) return null;
 
     return {
-      publicKey: parse(publicKey, publicKeyRegex),
+      publicKey: parse(publicKey),
+      pqPublicKey: parse(pqPublicKey),
       siteId: siteId,
     };
   } catch (err) {

--- a/packages/tracker/src/crypto.ts
+++ b/packages/tracker/src/crypto.ts
@@ -1,0 +1,88 @@
+import { xsalsa20poly1305 } from "@noble/ciphers/salsa";
+import { x25519 } from "@noble/curves/ed25519";
+import { hkdf } from "@noble/hashes/hkdf";
+import { sha256 } from "@noble/hashes/sha256";
+import { concatBytes } from "@noble/hashes/utils";
+import { ml_kem768 } from "@noble/post-quantum/ml-kem";
+import { base64url, utf8 } from "@scure/base";
+
+type EncodedKeyPair = {
+  public: string;
+  secret: string;
+};
+
+type KeyPair = {
+  publicKey: Uint8Array;
+  secretKey: Uint8Array;
+};
+
+type ReturnedKeyPair = EncodedKeyPair & {
+  keyPair: KeyPair;
+};
+
+function generateKeyPair(): ReturnedKeyPair {
+  const privateKey = x25519.utils.randomPrivateKey();
+  const publicKey = x25519.getPublicKey(privateKey);
+
+  return {
+    public: encodeKey(publicKey, "pk"),
+    secret: encodeKey(privateKey, "sk"),
+    keyPair: {
+      publicKey: publicKey,
+      secretKey: privateKey,
+    },
+  };
+}
+
+function encodeKey(key: Uint8Array, prefix: "pk" | "sk") {
+  return `trpkit.box.${prefix}.${base64url.encode(key)}`;
+}
+
+export function parse(input: string) {
+  const match = input.match(/^trpkit\.box\.sk\.([a-zA-Z0-9-_]+)$/);
+  if (!match) {
+    throw new Error("Invalid public key format");
+  }
+
+  return base64url.decode(match[1]);
+}
+
+export function encrypt(input: string, publicKey: Uint8Array, pqPublicKey: Uint8Array): string {
+  // Validate x25519 public key length
+  if (publicKey.length !== 32) {
+    throw new Error("Invalid x25519 public key length");
+  }
+
+  // Validate ML-KEM public key length
+  if (pqPublicKey.length !== 1184) {
+    throw new Error("Invalid ML-KEM public key length");
+  }
+
+  // Ensure input is not empty
+  if (!input) {
+    throw new Error("Input must be a string");
+  }
+
+  const nonce = window.crypto.getRandomValues(new Uint8Array(xsalsa20poly1305.nonceLength));
+
+  // Generate x25519 ephemeral key pair
+  const keyPair = generateKeyPair();
+  // Analytics script config contains the encoded public key, it is automatically decoded into Uint8Array when the script loads
+  const sharedSecret = x25519.getSharedSecret(keyPair.keyPair.secretKey, publicKey);
+
+  // ML-KEM 768 encapsulation
+  const { cipherText: pqCipherText, sharedSecret: pqSharedSecret } =
+    ml_kem768.encapsulate(pqPublicKey);
+
+  // Concatenate the shared secrets
+  const combinedSecrets = concatBytes(sharedSecret, pqSharedSecret);
+
+  // Derive the final symmetric key using HKDF
+  const finalKey = hkdf(sha256, combinedSecrets, undefined, undefined, 32);
+
+  // Encrypt the payload with xsalsa20poly1305 using the final symmetric key
+  const cipher = xsalsa20poly1305(finalKey, nonce);
+  const cipherText = cipher.encrypt(utf8.decode(input));
+
+  return `trpkit.pq.${base64url.encode(keyPair.keyPair.publicKey)}.${base64url.encode(pqCipherText)}.${base64url.encode(nonce)}.${base64url.encode(cipherText)}`;
+}

--- a/packages/tracker/src/event.ts
+++ b/packages/tracker/src/event.ts
@@ -1,5 +1,5 @@
-import { encrypt } from "@trpkit/crypto";
 import type { Config } from "./config";
+import { encrypt } from "./crypto";
 import { handleRequest } from "./request";
 
 export type BasePayload = {
@@ -51,6 +51,6 @@ export function createEvent(t: Event["t"], d: Event["d"]): Event {
 export function sendEvent(event: Event, config: Config) {
   if (/^(localhost|127\.0\.0\.1|\[::1?])$/.test(window.location.hostname)) return;
 
-  const payload = encrypt(JSON.stringify(event), config.publicKey);
+  const payload = encrypt(JSON.stringify(event), config.publicKey, config.pqPublicKey);
   handleRequest(config.siteId, payload);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,9 +277,21 @@ importers:
 
   packages/tracker:
     dependencies:
-      '@trpkit/crypto':
-        specifier: workspace:*
-        version: link:../crypto
+      '@noble/ciphers':
+        specifier: ^0.5.3
+        version: 0.5.3
+      '@noble/curves':
+        specifier: ^1.6.0
+        version: 1.6.0
+      '@noble/hashes':
+        specifier: ^1.5.0
+        version: 1.5.0
+      '@noble/post-quantum':
+        specifier: ^0.2.0
+        version: 0.2.0
+      '@scure/base':
+        specifier: ^1.1.8
+        version: 1.1.8
     devDependencies:
       '@types/node':
         specifier: ^20.16.5


### PR DESCRIPTION
Relocate the client-side cryptographic functions directly into the analytics script. Will be combing the KMS & Crypto packages into one and redoing the KMS to use post-quantum algorithms and replacing aes-gcm with xsalsa20poly1305. 